### PR TITLE
MSTG-NETWORK-4.2

### DIFF
--- a/rules/network/mstg-network-4.2.java
+++ b/rules/network/mstg-network-4.2.java
@@ -33,4 +33,29 @@ public class Test{
         //urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
         urlConnection.connect();
     }
+    public void test5(){
+        TrustManager[] trustManagers = new TrustManager[1];
+        trustManagers[0] = new PinningTrustManager(SystemKeyStore.getInstance(context), pins, 0);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustManagers, null);
+
+        HttpsURLConnection urlConnection = (HttpsURLConnection)url.openConnection();
+        test3();
+        urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+        urlConnection.connect();
+    }
+    public void test6(){
+        TrustManager[] trustManagers = new TrustManager[1];
+        trustManagers[0] = new PinningTrustManager(SystemKeyStore.getInstance(context), pins, 0);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustManagers, null);
+
+        HttpsURLConnection urlConnection;
+        urlConnection = (HttpsURLConnection)url.openConnection();
+        test3();
+        //urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+        urlConnection.connect();
+    }    
 }

--- a/rules/network/mstg-network-4.2.yaml
+++ b/rules/network/mstg-network-4.2.yaml
@@ -31,5 +31,7 @@ rules:
               $X.connect();
           - pattern-not: |
               HttpsURLConnection $X = ...;
+              ...
               $X.setSSLSocketFactory(...);
+              ...
               $X.connect();


### PR DESCRIPTION
Hi,

I made a small change to the rule, in order to match also if there is additional code between the instructions of the rule, by adding some "..." between them (I added also a couple of test methods to the related Java file).

Maybe the rule can be further generalized as follows, in order to increase the detection rate when the code has a different structure:

```yaml
      - patterns:
          - pattern: (HttpsURLConnection $X).connect();
          - pattern-not-inside: |
              (HttpsURLConnection $X).setSSLSocketFactory(...);
              ...
              (HttpsURLConnection $X).connect();
```

Please let me know which version do you prefer.

Thank you!
Federico

P.S. Sorry for the double PR. I wasn't aligned with the last commits.