### PR TITLE
More accurate MSTG-STORAGE-11

### DIFF
--- a/rules/storage/mstg-storage-11.yaml
+++ b/rules/storage/mstg-storage-11.yaml
@@ -5,7 +5,7 @@ rules:
       - xml
     metadata:
       authors:
-        - Riccardo Cardelli @gand3lf (IMQ Minded Security)
+        - Sparrrgh
       owasp-mobile: M1
       category: security
       area: storage
@@ -13,8 +13,11 @@ rules:
         - L2
       references:
         - https://github.com/OWASP/owasp-mastg/blob/v1.5.0/Document/0x05d-Testing-Data-Storage.md#testing-the-device-access-security-policy-mstg-storage-11
-    message: The application allows to use Android versions earlier than 23.
+    message: The application does not implement a Device-Access-Security policy.
     patterns:
-      - pattern: <uses-sdk android:minSdkVersion="$X" />
-      - metavariable-comparison:
-          comparison: int($X)<23
+      - pattern-regex: |
+          (?s)(.*)
+      - pattern-not-regex: (<action\s+android:name="android\.app\.action\.DEVICE_ADMIN_ENABLED"\/>)
+    paths:
+      include:
+        - "**/AndroidManifest.xml"


### PR DESCRIPTION
This rule is described in the documentation for MASTG as the enforcement of checks through Device Administration API and by querying Settings.Secure.
The current rule only checks the **example** in the documentation where an old Android version is used.

My rule does not search for Settings.Secure checks in the code, but it now checks at least for the usage of Device Administration API which is a bit more accurate to the documentation from OWASP.